### PR TITLE
Refactor getReleaseByTags to require single Tags parameter

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -44,11 +44,10 @@ export async function run(): Promise<void> {
 		context.payload.pull_request?.merged
 	) {
 		// Get the previous release built
-		const previousRelease = await balena.getReleaseByTags(
-			fleet,
-			context.payload.pull_request?.head.sha,
-			context.payload.pull_request?.id,
-		);
+		const previousRelease = await balena.getReleaseByTags(fleet, {
+			sha: context.payload.pull_request?.head.sha,
+			pullRequestId: context.payload.pull_request?.id,
+		});
 		if (previousRelease && !previousRelease.isFinal) {
 			await balena.finalize(previousRelease.id);
 		} else {
@@ -78,7 +77,7 @@ export async function run(): Promise<void> {
 	releaseId = await balena.push(fleet, src, {
 		tags: {
 			sha: context.payload.pull_request?.head.sha,
-			pullRequest: context.payload.pull_request?.id,
+			pullRequestId: context.payload.pull_request?.id,
 		},
 	});
 


### PR DESCRIPTION
This replaces the 2 specific parameters to just being 1 Tags parameter. Makes adding more tags in the future easier rather then add more and more fn params