### PR TITLE
Cache previous builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Inputs are provided using the `with:` section of your workflow YML file.
 | balena_token | API key to balenaCloud | true | |
 | fleet | The slug of the fleet (eg: `my_org/sample_fleet`) for which the release is for | true | |
 | environment | Domain of API hosting your fleets | false | balena-cloud.com |
+| cache | If a release matching the commit already exists do not build again | false | true |
 | versionbot | Tells action to use Versionbot branch for versioning | false | false |
 | create_ref | Create a ref on the git commit with the release version | false | false |
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Attempt to tag the git commit with the release version'
     required: false
     default: false
+  cache:
+    description: 'If a release matching the commit already exists do not build'
+    required: false
+    default: true
 outputs:
   release_id:
     description: 'ID of the release built'

--- a/src/action.ts
+++ b/src/action.ts
@@ -59,15 +59,16 @@ export async function run(): Promise<void> {
 			sha: context.payload.pull_request?.head.sha,
 			pullRequestId: context.payload.pull_request?.id,
 		});
-		if (previousRelease && !previousRelease.isFinal) {
-			await balena.finalize(previousRelease.id);
-		} else {
-			// Throw an error so the action fails
+		if (!previousRelease) {
 			throw new Error(
 				'Action reached point of finalizing a release but did not find one',
 			);
+		} else if (previousRelease.isFinal) {
+			core.info('Release is already finalized so skipping.');
+			return;
 		}
-		return; // Action is complete because we finalized the release previously built
+		// Finalize release and done!
+		return await balena.finalize(previousRelease.id);
 	}
 
 	// If the action has made it this far then we will build a draft release


### PR DESCRIPTION
closes #42 

I didn't think this change would be useful but after having 8/9 runs of this action complete in parallel and the last one failed I had to re run them all...with this change the actions should exit much faster. 

See: 

![image](https://user-images.githubusercontent.com/3946250/141061596-78a87e0c-2c76-4160-91e6-0367ed72f090.png)
