### PR TITLE
Catch exception if git reference already exists when creating

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -89,6 +89,13 @@ export async function run(): Promise<void> {
 	core.setOutput('release_id', releaseId);
 
 	if (core.getBooleanInput('create_ref', { required: false })) {
-		await createRef(rawVersion, context.payload.pull_request?.head.sha);
+		try {
+			await createRef(rawVersion, context.payload.pull_request?.head.sha);
+		} catch (e: any) {
+			if (e.message !== 'Reference already exists') {
+				throw e;
+			}
+			core.info('Git reference already exists.');
+		}
 	}
 }

--- a/src/github-utils.ts
+++ b/src/github-utils.ts
@@ -43,7 +43,7 @@ export async function createRef(tag: string, sha: string): Promise<string> {
 	const token = core.getInput('github_token', { required: true });
 	const octokit = github.getOctokit(token);
 
-	core.debug(`Creating refs/tags/${tag}`);
+	core.info(`Creating refs/tags/${tag}`);
 
 	const response = await octokit.rest.git.createRef({
 		owner: github.context.repo.owner,
@@ -51,9 +51,6 @@ export async function createRef(tag: string, sha: string): Promise<string> {
 		ref: `refs/tags/${tag}`,
 		sha,
 	});
-
-	core.debug(JSON.stringify(response.data));
-	// TODO: catch 'ref already exists'	errors and don't throw
 
 	return response.data.url;
 }


### PR DESCRIPTION
This would always throw an error because the tag would be created on PR open/sync and then on merge we would tag the same commit and fail.

Change-type: patch
Signed-off-by: Miguel Casqueira <miguel@balena.io>