### PR TITLE
Default source input to empty string instead of false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,9 @@ inputs:
     required: false
     default: true
   source:
-    description: 'Specify custom source path relative to workspace to build in'
+    description: 'Specify custom path to Dockerfile/docker-compose for building release images'
     required: false
-    default: false
+    default: ''
 outputs:
   release_id:
     description: 'ID of the release built'

--- a/src/action.ts
+++ b/src/action.ts
@@ -16,9 +16,10 @@ export async function run(): Promise<void> {
 	const target = context.payload.repository.master_branch;
 	// Name of the fleet to build for
 	const fleet = core.getInput('fleet', { required: true });
-	// File path to release source code
-	const src =
-		`${process.env.GITHUB_WORKSPACE}/${core.getInput('source')}` || '';
+	// Custom location for Dockerfile/docker-compose (instead of being in root of GITHUB_WORKSPACE)
+	const dockerfileLocation = core.getInput('source', { required: false });
+	// File path to build release images from
+	const src = `${process.env.GITHUB_WORKSPACE!}/${dockerfileLocation}`;
 	// ID of release built
 	let releaseId: string | null = null;
 	// Version of release built


### PR DESCRIPTION
The action before would error by trying to build in a folder called false as this is the default value for source. This resolves that issue by making the default an empty string. 

```
 /usr/bin/balena push balena_os/armv7hf-supervisor --source /github/workspace/false --release-tag balena-ci-commit-sha 526787c3711a3ab3d0c8e31c6ba61a6894e074b8 balena-ci-id 778848383 --draft
Could not access source folder: "/github/workspace/false"

Error: The process '/usr/bin/balena' failed with exit code 1
```