### PR TITLE
Update multicast-dns to a new commit since the upstream was rebased

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12756,7 +12756,7 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
-          "version": "git+https://github.com/resin-io-modules/multicast-dns.git#a15c63464eb43e8925b187ed5cb9de6892e8aacc",
+          "version": "git+https://github.com/resin-io-modules/multicast-dns.git#db98d68b79bbefc936b6799de9de1038ba49f85d",
           "from": "git+https://github.com/resin-io-modules/multicast-dns.git#listen-on-all-interfaces",
           "requires": {
             "dns-packet": "^1.0.1",


### PR DESCRIPTION
Otherwise the npm install will fail due to the missing commit.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>
Resolves: https://github.com/balena-io/balena-ci/issues/66